### PR TITLE
Add SAM histopathology models

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To keep updated with the latest samapi server, follow the instructions [here](ht
 #### Point prompt
 
 1. Select `Extensions` > `SAM` from the menu bar.
-2. Select the `Prompt` tab in the `Segment Anyghing Model` dialog.
+2. Select the `Prompt` tab in the `Segment Anything Model` dialog.
 2. Select a point tool by clicking the icon.
 3. Add foreground points.
 4. (Optional) add background points.
@@ -84,7 +84,7 @@ To keep updated with the latest samapi server, follow the instructions [here](ht
 ### SamAutomaticMaskGenerator
 
 1. Select `Extensions` > `SAM` from the menu bar.
-2. Select the `Auto mask` tab in the `Segment Anyghing Model` dialog.
+2. Select the `Auto mask` tab in the `Segment Anything Model` dialog.
 3. Set parameters.
 4. Press the `Run` button.
 
@@ -115,7 +115,7 @@ To keep updated with the latest samapi server, follow the instructions [here](ht
 ### Register SAM weights from URL
 
 1. Select `Extensions` > `SAM` from the menu bar.
-2. Press the `Register` button in the `Segment Anyghing Model` dialog.
+2. Press the `Register` button in the `Segment Anything Model` dialog.
 
 <img src="https://github.com/ksugar/qupath-extension-sam/releases/download/assets/qupath-sam-register-weights-from-url.png" width="768">
 

--- a/README.md
+++ b/README.md
@@ -143,12 +143,13 @@ Here is a list of SAM weights that you can register from the URL.
         </tr>
     </thead>
     <tbody>
+	# MicroSAM models
         <tr>
             <td>vit_h</td>
             <td>vit_h_lm</td>
             <td><a href="https://zenodo.org/record/8250299/files/vit_h_lm.pth?download=1">https://zenodo.org/record/8250299/files/vit_h_lm.pth?download=1</a></td>
-            <td rowspan="4">Archit, A. et al. <a href="https://doi.org/10.1101/2023.08.21.554208">Segment Anything for
-                    Microscopy.</a> bioRxiv 2023. doi:10.1101/2023.08.21.554208<br><br><a href="https://github.com/computational-cell-analytics/micro-sam">https://github.com/computational-cell-analytics/micro-sam</a></td>
+            <td rowspan="4">Archit, A. et al. <a href="https://doi.org/10.1038/s41592-024-02580-4">Segment Anything for
+                    Microscopy.</a> Nature Methods 2025.<br><br><a href="https://github.com/computational-cell-analytics/micro-sam">https://github.com/computational-cell-analytics/micro-sam</a></td>
         </tr>
         <tr>
             <td>vit_b</td>
@@ -164,6 +165,19 @@ Here is a list of SAM weights that you can register from the URL.
             <td>vit_b</td>
             <td>vit_b_em</td>
             <td><a href="https://zenodo.org/record/8250260/files/vit_b_em.pth?download=1">https://zenodo.org/record/8250260/files/vit_b_em.pth?download=1</a></td>
+        </tr>
+	# PathoSAM models
+	<tr>
+            <td>vit_h</td>
+            <td>vit_h_histopathology</td>
+            <td><a href="https://owncloud.gwdg.de/index.php/s/L7AcvVz7DoWJ2RZ/download">https://owncloud.gwdg.de/index.php/s/L7AcvVz7DoWJ2RZ/download</a></td>
+            <td rowspan="2">Greibel, T. et al. <a href="https://doi.org/10.48550/arXiv.2502.00408">Segment Anything for
+                    Histopathology.</a> arXiv 2025.<br><br><a href="https://github.com/computational-cell-analytics/patho-sam">https://github.com/computational-cell-analytics/patho-sam</a></td>
+        </tr>
+        <tr>
+            <td>vit_b</td>
+            <td>vit_b_histopathology</td>
+            <td><a href="https://owncloud.gwdg.de/index.php/s/sBB4H8CTmIoBZsQ/download">https://owncloud.gwdg.de/index.php/s/sBB4H8CTmIoBZsQ/download</a></td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
Hi @ksugar,

Thank you so much for this extension. It's really awesome and super flexible to use!

In @constantinpape's group, we recently built a generalist model for nucleus instance segmentation in histopathology, called [PathoSAM](https://github.com/computational-cell-analytics/patho-sam).

And we tried out our `patho-sam` models, and registering them works out-of-the-box with the download URLs I added (let me know if it works at your end as well)

 Seeing some interests on `image.sc` for the histopathology models (https://forum.image.sc/t/using-micro-sam-models-in-qupath-sam-extension/109845), I would like to add them to the documentation. Let me know if all looks good.

PS. I also changed the doi of `micro-sam` to our latest published version! :)