### PR TITLE
v0.9.0 -> v0.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # QuPath extension SAM
 
-### Latest release v0.9.0: Support for SAM3!
+### Latest release v0.9: Support for SAM3!
 
 The extension now supports [SAM3](https://github.com/facebookresearch/segment-anything-3) models for enhanced segmentation and tracking capabilities.
+
+<video controls width="768">
+    <source src="https://github.com/ksugar/qupath-extension-sam/releases/download/v0.9.0/sam3_usage_CMU-1.mp4" type="video/mp4">
+    Your browser does not support the video tag.
+</video>
 
 The command history is also now available from `Automate` > `Show workflow command history` and `Automate` > `Create command history script` in the menu bar.
 
@@ -172,7 +177,7 @@ This is a part of the following paper. Please [cite](#citation) it when you use 
 
 ## Install
 
-Drag and drop [the extension file](https://github.com/ksugar/qupath-extension-sam/releases/download/v0.9.0/qupath-extension-sam-0.9.0.jar) to [QuPath](https://qupath.github.io) and restart it.
+Drag and drop [the extension file](https://github.com/ksugar/qupath-extension-sam/releases/download/v0.9.1/qupath-extension-sam-0.9.1.jar) to [QuPath](https://qupath.github.io) and restart it.
 
 Since QuPath v0.5.0, you can install the extension from the extension manager dialog by specifying `Owner` and `Repository` as shown below.
 
@@ -190,7 +195,7 @@ To update the `qupath-extension-sam`, follow the following instructions.
 
 1. Open extensions directory from `Extensions` > `Installed extensions` > `Open extensions directory`
    ![](https://github.com/ksugar/qupath-extension-sam/releases/download/assets/open-extensions-directory.png)
-2. Replace `qupath-extension-sam-x.y.z.jar` with [the latest version of the extension file](https://github.com/ksugar/qupath-extension-sam/releases/download/v0.9.0/qupath-extension-sam-0.9.0.jar). If you are using QuPath v0.4.x, you need to install [the extension file for QuPath v0.4.x](https://github.com/ksugar/qupath-extension-sam/releases/download/v0.4.1/qupath-extension-sam-0.4.1.jar), which is now deprecated.
+2. Replace `qupath-extension-sam-x.y.z.jar` with [the latest version of the extension file](https://github.com/ksugar/qupath-extension-sam/releases/download/v0.9.1/qupath-extension-sam-0.9.1.jar). If you are using QuPath v0.4.x, you need to install [the extension file for QuPath v0.4.x](https://github.com/ksugar/qupath-extension-sam/releases/download/v0.4.1/qupath-extension-sam-0.4.1.jar), which is now deprecated.
 3. Restart QuPath application.
 
 Please note that you need to also update the [samapi](https://github.com/ksugar/samapi) server.  
@@ -359,6 +364,11 @@ If you select a class in `Auto set` in the Annotations tab, it is used for a new
 
 ## Updates
 
+### v0.9.1
+
+- Enable the confidence threshold setting only for SAM3 models.
+- Accept SAM3 requests without any text or bounding box prompts. This enables the use of SAM3 with a pre-existing inference state. The [samapi](https://github.com/ksugar/samapi) server version must be `v0.7.1` or above.
+ 
 ### v0.9.0
 - Support SAM3 (you need to use the [samapi](https://github.com/ksugar/samapi) server `v0.7.0` or above).
 - Accept server URL without a trailing slash.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 qupathExtension {
     name = "qupath-extension-sam"
     group = "org.elephant.sam.qupath"
-    version = "0.9.0"
+    version = "0.9.1"
     description = "QuPath extension for Segment Anything Model (SAM)"
     automaticModule = "org.elephant.sam"
 }

--- a/src/main/java/org/elephant/sam/commands/SAMMainCommand.java
+++ b/src/main/java/org/elephant/sam/commands/SAMMainCommand.java
@@ -364,7 +364,7 @@ public class SAMMainCommand implements Runnable {
     /**
      * Confidence thresh parameter.
      */
-    private static final double DEFAULT_CONFIDENCE_THRESH = 0.5;
+    private static final double DEFAULT_CONFIDENCE_THRESH = 0.4;
     private final DoubleProperty confidenceThreshProperty = PathPrefs.createPersistentPreference(
             "ext.SAM.autoMask.confidenceThresh", DEFAULT_CONFIDENCE_THRESH);
 

--- a/src/main/java/org/elephant/sam/commands/SAMMainCommand.java
+++ b/src/main/java/org/elephant/sam/commands/SAMMainCommand.java
@@ -1444,11 +1444,6 @@ public class SAMMainCommand implements Runnable {
                         qupath.getViewer().getZPosition(),
                         qupath.getViewer().getTPosition()))
                 .collect(Collectors.toList());
-        if (textPrompt == null || textPrompt.isEmpty() && (positiveBboxes == null || positiveBboxes.isEmpty())) {
-            logger.warn("Cannot submit task - text prompt and positive bboxes must not both be empty!");
-            updateInfoText("No text prompt or positive bboxes to use");
-            return;
-        }
         logger.info("Submitting task for {} positive and {} negative bboxes",
                 positiveBboxes.size(), negativeBboxes.size());
         SAM3DetectionTask task = SAM3DetectionTask.builder(qupath.getViewer())

--- a/src/main/java/org/elephant/sam/ui/SAMPromptPane.java
+++ b/src/main/java/org/elephant/sam/ui/SAMPromptPane.java
@@ -259,6 +259,7 @@ public class SAMPromptPane extends GridPane {
         Spinner<Double> confidenceThreshSpinner = SAMUIUtils.createDoubleSpinner(
                 0.0, 1.0, command.getConfidenceThreshProperty(), 0.01,
                 "A filtering threshold in [0,1], using the model's predicted mask quality.");
+        confidenceThreshSpinner.disableProperty().bind(isSAM3CompatibleBinding.not());
         GridPane confidenceThreshPane = SAMUIUtils.createColumnPane(
                 new Label("Pred IoU thresh"), confidenceThreshSpinner);
         VBox vbox = new VBox(sam3Label, textPane, cbResetPrompts, confidenceThreshPane);


### PR DESCRIPTION
# Overview

- Enable the confidence threshold setting only for SAM3 models.
- Accept SAM3 requests without any text or bounding box prompts. This enables the use of SAM3 with a pre-existing inference state. The [samapi](https://github.com/ksugar/samapi) server version must be `v0.7.1` or above.